### PR TITLE
Check that histories directory exists before trying to create.

### DIFF
--- a/bin/npm-postinstall
+++ b/bin/npm-postinstall
@@ -1,0 +1,13 @@
+const path = require('path');
+const fs = require('fs');
+const { exec } = require('child_process');
+
+const historiesPath = path.normalize('./histories');
+
+if(!fs.existsSync(historiesPath)) {
+  exec('mkdir ' + historiesPath, (error) => {
+    if (error) {
+      throw new Error(`error making histories directory: ${error}`);
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Line focuser",
   "main": "src/locus.js",
   "scripts": {
-    "postinstall": "mkdir ./histories"
+    "postinstall": "node bin/npm-postinstall"
   },
   "files": [
     "src/"


### PR DESCRIPTION
Add post-install script that should be cross-platform.
Closes #18